### PR TITLE
Fix single-quote string typo

### DIFF
--- a/articles/quickstart/backend/ruby/01-authorization.md
+++ b/articles/quickstart/backend/ruby/01-authorization.md
@@ -136,7 +136,7 @@ The `/public` endpoint does not require to use the `authenticate!` method.
 
 ```rb
 get '/api/public' do
-  json( message: 'Hello from a public endpoint! You don't need to be authenticated to see this.' )
+  json( message: "Hello from a public endpoint! You don't need to be authenticated to see this." )
 end
 ```
 


### PR DESCRIPTION
String was using single quotes, but contained a contraction causing a highlighting issue.

Possibly the smallest PR I've ever created.

<!---
Notes:
- Your PR should conform to our [Contributing Guidelines](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md)
- If applicable, add details to the [update feed](https://github.com/auth0/docs/tree/master/updates)
- Make sure your PR gets deployed to a Heroku [Review App](https://github.com/auth0/docs/blob/master/CONTRIBUTING.md#review-apps) without errors
- Please include a short description
- If your PR is a work in progress, title it [DO NOT MERGE]
--->
